### PR TITLE
Add client id to config

### DIFF
--- a/lib/auth0_current_user/api_secured.rb
+++ b/lib/auth0_current_user/api_secured.rb
@@ -58,7 +58,7 @@ module ApiSecured
   end
 
   def configuration
-    @configuration ||= Configuration.new
+    @configuration ||= Auth0CurrentUser.configuration
   end
 
 end

--- a/lib/auth0_current_user/configuration.rb
+++ b/lib/auth0_current_user/configuration.rb
@@ -1,11 +1,12 @@
 module Auth0CurrentUser
   class Configuration
-    attr_accessor :auth0_domain, :auth0_audience, :authenticated_klass
+    attr_accessor :auth0_domain, :auth0_audience, :authenticated_klass, :client_id
 
     def initialize
       @auth0_domain = nil
       @auth0_audience = nil
       @authenticated_klass = :user
+      @client_id = nil
     end
     
   end

--- a/lib/auth0_current_user/version.rb
+++ b/lib/auth0_current_user/version.rb
@@ -1,3 +1,3 @@
 module Auth0CurrentUser
-  VERSION = "0.2.1"
+  VERSION = "0.3"
 end

--- a/lib/auth0_current_user/web_secured.rb
+++ b/lib/auth0_current_user/web_secured.rb
@@ -1,3 +1,5 @@
+require 'auth0_current_user/configuration'
+
 module Auth0CurrentUser
   module WebSecured
     extend ActiveSupport::Concern
@@ -35,11 +37,19 @@ module Auth0CurrentUser
     end
 
     def logged_in_using_omniauth?
-      redirect_to '/' unless session[:userinfo].present? && Time.zone.now < Time.zone.at(userinfo['exp'])
+      redirect_to authorization_endpoint unless session[:userinfo].present? && Time.zone.now < Time.zone.at(userinfo['exp'])
+    end
+
+    def authorization_endpoint
+      @_authorization_endpoint ||= "https://#{configuration.auth0_domain}/authorize?response_type=code&client_id=#{configuration.client_id}"
     end
 
     def userinfo
       session['userinfo'] || {}
+    end
+
+    def configuration
+      @configuration ||= Auth0CurrentUser.configuration
     end
 
   end


### PR DESCRIPTION
- Adds client_id to configuration in order to facilitate redirects. 
- Refactors ApiSecured#configuration to ensure initialized values are used